### PR TITLE
 add support for selection event trigger on double-click

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ export type TreeNodeProps = {
   toggleCallback?: Function,
   useLocalState?: boolean,
   paginated?: boolean,
+  doubleClickSelect?: boolean,
 };
 ```
 
@@ -367,6 +368,7 @@ export type ListItemProps = {
   node: Node,
   children: any,
   onClick: Function,
+  onDoubleClick: Function,
   onKeyPress: Function,
 };
 ```

--- a/README.md
+++ b/README.md
@@ -130,6 +130,9 @@ Format (one node with one child):
 
 * `toggleCallback: Function`: function called with `(e: Event, node: Node)` as a callback to node expand/collapse event.
 * `selectCallback: Function`: function called with `(e: Event, node: Node)` as a callback to node selection event.
+   * by default, will trigger on the OnClick event of the node. 
+   * if `doubleClickSelect = true` then it will fire on the OnDoubleClick event
+   * does not support both OnClick and OnDoubleClick events for node selection
 
 ##### Style Overrides
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-lazy-paginated-tree",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description":
     "Customizable React Tree-View with Lazy Loading and Pagination",
   "repository": {

--- a/src/components/ListItem.js
+++ b/src/components/ListItem.js
@@ -4,10 +4,17 @@ import React from 'react';
 import MUIListItem from '@material-ui/core/ListItem';
 import type { ListItemProps } from '../types';
 
-const ListItem = ({ theme, onClick, onKeyPress, children }: ListItemProps) => (
+const ListItem = ({
+  theme,
+  onClick,
+  onKeyPress,
+  children,
+  onDoubleClick,
+}: ListItemProps) => (
   <MUIListItem
     button
     onClick={onClick}
+    onDoubleClick={onDoubleClick}
     onKeyPress={onKeyPress}
     style={theme.listItemStyle}
     className={theme.listItemClassName}

--- a/src/components/Tree.js
+++ b/src/components/Tree.js
@@ -51,6 +51,7 @@ class Tree extends Component<TreeProps> {
       selectCallback,
       useLocalState,
       paginated,
+      doubleClickSelect,
     } = this.props;
 
     const parsedNodes = parse ? parse(nodes) : nodes;
@@ -79,6 +80,7 @@ class Tree extends Component<TreeProps> {
             selectCallback={selectCallback}
             useLocalState={useLocalState}
             paginated={paginated}
+            doubleClickSelect={doubleClickSelect}
           />
         ))}
       </ul>

--- a/src/components/TreeNode.js
+++ b/src/components/TreeNode.js
@@ -208,6 +208,7 @@ class TreeNode extends Component<TreeNodeProps, TreeNodeState> {
       Loading,
       DepthPadding,
       paginated,
+      doubleClickSelect,
     }: TreeNodeProps = this.props;
 
     const {
@@ -218,14 +219,21 @@ class TreeNode extends Component<TreeNodeProps, TreeNodeState> {
     }: TreeNodeState = this.state;
 
     const children = this.renderChildren();
-
+    //only supports single click OR double click
+    let doubleClickFunction = doubleClickSelect
+      ? e => this.select(e, node)
+      : undefined;
+    let clickFunction = doubleClickSelect
+      ? undefined
+      : e => this.select(e, node);
     return (
       <React.Fragment>
         {/* ListItem: Overridable container component */}
         <ListItem
           theme={theme}
           node={node}
-          onClick={e => this.select(e, node)}
+          onClick={clickFunction}
+          onDoubleClick={doubleClickFunction}
           onKeyPress={e => this.onKeySelect(e, node)}
         >
           {/* DepthPadding: Overridable Component for hierarchical indentation */}

--- a/src/types/index.js
+++ b/src/types/index.js
@@ -89,6 +89,7 @@ export type TreeNodeProps = {
   toggleCallback?: Function,
   useLocalState?: boolean,
   paginated?: boolean,
+  doubleClickSelect?: boolean,
 };
 
 export type TreeNodeState = {
@@ -138,6 +139,7 @@ export type ListItemProps = {
   node: Node,
   children: any,
   onClick: Function,
+  onDoubleClick: Function,
   onKeyPress: Function,
 };
 


### PR DESCRIPTION
Adds property doubleClickSelect to Tree that will cause selectCallback() to trigger from double clicks rather than single clicks or checkbox checks.
Tech doesn't support having onClick AND onDoubleClick callbacks so it cases on the bool to set the callbacks.